### PR TITLE
Implement perlin noise terrain generation

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -1,0 +1,19 @@
+/**
+* CONSTANTS
+*/
+
+// sketch frame rate
+const FRAME_RATE = 30;
+
+// sketch size values
+const HEIGHT = 400;
+const WIDTH = 1000;
+
+// terrain parameters
+const RESOLUTION = 20;
+const WIDTH_OFFSET = 800;
+const HEIGHT_OFFSET = 200;
+
+// colors
+const BACKGROUND_COLOR = [118, 168, 218];
+const TERRAIN_COLOR = [239, 84, 100, 80];

--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
     <link rel='shortcut icon' type='image/x-icon' href='assets/images/favicon.ico'/>
     <script src="libs/p5.js"></script>
     <script src="libs/p5.sound.js"></script>
+    <script src="libs/terrain.js"></script>
+    <script src="config/config.js"></script>
     <script src="src/sketch.js"></script>
   </head>
   <body>

--- a/libs/terrain.js
+++ b/libs/terrain.js
@@ -1,0 +1,150 @@
+/**
+ * Perlin noise generated terrain abstraction.
+ */
+
+class Terrain
+{
+    /**
+     * I initialize myself.
+     * 
+     * Args:
+     *  width (number): terrain width
+     *  height (number): terrain height
+     *  resolution (number): terrain resolution
+     * 
+     * Returns:
+     *  undefined.
+     */
+    constructor(width, height, resolution)
+    {
+        // store components
+        this.terrain = [];
+        this.seed = 0;
+
+        // store parameters
+        this.width = width;
+        this.height = height;
+        this.resolution = resolution;
+    }
+
+    /**
+     * I return my number of rows.
+     * 
+     * Returns:
+     *  _ (number): number of rows
+     */
+    get rows()
+    {
+        return this.height / this.resolution;
+    }
+
+    /**
+     * I return my number of columns.
+     * 
+     * Returns:
+     *  _ (number): number of columns
+     */
+    get columns()
+    {
+        return this.width / this.resolution;
+    }
+
+    /**
+     * I load my initial state.
+     * 
+     * Returns:
+     *  undefined.
+     */
+    setup()
+    {
+        this.setupNoise();
+    }
+
+    /**
+     * I load my initial perlin noise space state.
+     * 
+     * Returns:
+     *  undefined.
+     */
+    setupNoise()
+    {
+        // setup terrain
+        for(let row = 0; row < this.rows * 3; row++)
+        {
+            this.terrain.push(Array(this.columns).fill(0));
+        }
+    }
+
+    /**
+     * I update the terrain state in one step.
+     * 
+     * Args:
+     *  step(Object): x and y dimensions space coordinates step size
+     * 
+     * Returns:
+     *  undefined.
+     */
+    update(step)
+    {
+        // initialize perlin noise space current coordinates
+        let coordinates = {x: 0, y: 0};
+        
+        // update terrain
+        coordinates.y = this.seed;
+        for(let row = 0; row < this.rows; row++)
+        {
+            coordinates.x = 0;
+            for(let column = 0; column < this.columns; column++)
+            {
+                this.terrain[column][row] = map(noise(coordinates.x, coordinates.y), 0, 1, -100, 100);
+                coordinates.x += step.x;
+            }
+            coordinates.y += step.y;
+        }
+
+        // update seed
+        this.seed -= step.speed;
+    }
+
+    /**
+     * I render this terrain state.
+     * 
+     * Returns:
+     *  undefined.
+     */
+    render()
+    {
+        // push transformation matrix
+        push();
+
+        // rotate 60 degrees
+        rotateX(PI / 3);
+
+        // adjust sketch centering
+        translate(-this.width / 2, -this.height / 2);
+
+        // set mesh color
+        strokeWeight(0);
+        fill(...TERRAIN_COLOR);
+
+        // draw terrain
+        for(let row = 0; row < this.rows - 1; row++)
+        {
+            // start drawing triangles strip
+            beginShape(TRIANGLE_STRIP);
+
+            // add vertices
+            for(let column = 0; column < this.columns; column++)
+            {
+                vertex(column * this.resolution, row * this.resolution, this.terrain[column][row]);
+                vertex(column * this.resolution, (row + 1) * this.resolution, this.terrain[column][row + 1]);
+            }
+            
+            // stop drawing triangles strip
+            endShape();
+        }
+
+        // pop transformation matrix
+        pop();
+    }
+}

--- a/src/sketch.js
+++ b/src/sketch.js
@@ -1,6 +1,10 @@
 /**
-* CONSTANTS AND DEFINITIONS
+* DEFINITIONS
 */
+
+// perlin noise terrain container
+let terrain;
+
 // soundtrack p5.SoundFile container
 let soundtrack;
 
@@ -23,11 +27,18 @@ function preload() {
  */
 function setup()
 {
-  // create dummy canvas
-  createCanvas(1, 1);
+    // set sketch frame rate
+    frameRate(FRAME_RATE);
 
-  // play soundtrack in a loop
-  soundtrack.loop();
+    // create canvas and set renderer as WEBGL
+    createCanvas(WIDTH, HEIGHT, WEBGL);
+
+    // play soundtrack in a loop
+    soundtrack.loop();
+
+    // setup terrain
+    terrain = new Terrain(WIDTH + WIDTH_OFFSET, HEIGHT + HEIGHT, RESOLUTION);
+    terrain.setup();
 }
 
 /**
@@ -38,5 +49,12 @@ function setup()
  */
 function draw()
 {
+    // set background color
+    background(...BACKGROUND_COLOR);
 
+    // update terrain
+    terrain.update({x: 0.2, y: 0.2, speed: 0.18});
+
+    // draw terrain
+    terrain.render();
 }


### PR DESCRIPTION
This PR implements the sketch perlin noise terrain generation. 

Although the code must be severely refactored, it might be good to merge as it is now so it unblocks further contributions.

First commit is: `Create WebGL canvas`
Depends on: `None`